### PR TITLE
[FIX] Update rosbridge image to include SLAM Toolbox

### DIFF
--- a/docker/compose/docker-compose_slam_unity.yml
+++ b/docker/compose/docker-compose_slam_unity.yml
@@ -20,7 +20,7 @@ services:
     command: "ros2 launch /workspace/demo/slam.xml"
 
   rosbridge:
-    image: registry.screamtrumpet.csie.ncku.edu.tw/pros_images/pros_base_image:latest
+    image: registry.screamtrumpet.csie.ncku.edu.tw/pros_images/pros_jetson_driver_image:latest
     env_file:
       - .env
     networks:


### PR DESCRIPTION
- Changed rosbridge launch image to one that includes SLAM Toolbox
- Necessary to handle map reset signals from SLAM Toolbox